### PR TITLE
refactor(tests): use t.Setenv in place of os.Setenv

### DIFF
--- a/pkg/installers/pip/detect_test.go
+++ b/pkg/installers/pip/detect_test.go
@@ -5,7 +5,6 @@
 package pip_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/paketo-buildpacks/packit/v2"
@@ -50,11 +49,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 		context("when BP_PIP_VERSION is set", func() {
 			it.Before(func() {
-				Expect(os.Setenv("BP_PIP_VERSION", "some-version")).To(Succeed())
-			})
-
-			it.After(func() {
-				Expect(os.Unsetenv("BP_PIP_VERSION")).To(Succeed())
+				t.Setenv("BP_PIP_VERSION", "some-version")
 			})
 
 			it("returns a build plan that provides the version of pip from BP_PIP_VERSION", func() {
@@ -85,7 +80,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 			context("when the provided version is of the form X.Y", func() {
 				it.Before(func() {
-					Expect(os.Setenv("BP_PIP_VERSION", "2.11")).To(Succeed())
+					t.Setenv("BP_PIP_VERSION", "2.11")
 				})
 
 				it("selects the version X.Y.0", func() {
@@ -118,7 +113,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 			context("when the provided version is of the form X.Y.Z", func() {
 				it.Before(func() {
-					Expect(os.Setenv("BP_PIP_VERSION", "22.1.3")).To(Succeed())
+					t.Setenv("BP_PIP_VERSION", "22.1.3")
 				})
 
 				it("selects the exact provided version X.Y.Z", func() {
@@ -151,7 +146,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 			context("when the provided version is of some other form", func() {
 				it.Before(func() {
-					Expect(os.Setenv("BP_PIP_VERSION", "some.other")).To(Succeed())
+					t.Setenv("BP_PIP_VERSION", "some.other")
 				})
 
 				it("selects the exact provided version", func() {

--- a/pkg/installers/poetry/detect_test.go
+++ b/pkg/installers/poetry/detect_test.go
@@ -78,11 +78,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 	context("when the BP_POETRY_VERSION is set", func() {
 		it.Before(func() {
-			Expect(os.Setenv("BP_POETRY_VERSION", "some-version")).To(Succeed())
-		})
-
-		it.After(func() {
-			Expect(os.Unsetenv("BP_POETRY_VERSION")).To(Succeed())
+			t.Setenv("BP_POETRY_VERSION", "some-version")
 		})
 
 		it("returns a plan that requires that version of poetry", func() {

--- a/pkg/installers/uv/detect_test.go
+++ b/pkg/installers/uv/detect_test.go
@@ -41,9 +41,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	context("when the BP_UV_VERSION is NOT set", func() {
-		it.Before(func() {
-			Expect(os.Unsetenv("BP_UV_VERSION")).To(Succeed())
-		})
 		it("returns a plan that provides uv", func() {
 			result, err := detect(packit.DetectContext{
 				WorkingDir: workingDir,
@@ -61,11 +58,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 	context("when the BP_UV_VERSION is set", func() {
 		it.Before(func() {
-			Expect(os.Setenv("BP_UV_VERSION", "some-version")).To(Succeed())
-		})
-
-		it.After(func() {
-			Expect(os.Unsetenv("BP_UV_VERSION")).To(Succeed())
+			t.Setenv("BP_UV_VERSION", "some-version")
 		})
 
 		it("returns a plan that requires that version of poetry", func() {

--- a/pkg/installers/uv/init_test.go
+++ b/pkg/installers/uv/init_test.go
@@ -15,7 +15,7 @@ import (
 func TestUnit(t *testing.T) {
 	suite := spec.New("uv", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("Build", testBuild)
-	suite("Detect", testDetect)
+	suite("Detect", testDetect, spec.Sequential())
 	suite("InstallProcess", testUvInstallProcess)
 	suite("Parser", testUvLockParser)
 	suite.Run(t)


### PR DESCRIPTION
## Describe your changes

This PR change all the calls to `os.Setenv` by calls to `t.Setenv`.

This ensures proper cleanup after use. It also requires sequential (vs parallel) test execution.

This is good since there might be race conditions and the tests will sometime fail because the variable was unset before the test executes.
