### PR TITLE
chore: update depencies

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -266,6 +266,11 @@ api = "0.8"
     id = "poetry"
     patches = 2
 
+  [[metadata.dependency-constraints]]
+    constraint = "2.3.*"
+    id = "poetry"
+    patches = 2
+
   # uv
   [[metadata.dependencies]]
     arch = "amd64"


### PR DESCRIPTION
## Describe your changes

This PR does two things:

- use correct name for uv constraint
- add poetry 2.3

This shall fix the buildpack.toml updates.
