### PR TITLE
chore: change package manager for opt-in tests

### DIFF
--- a/integration/installers/pm_mandatory_test.go
+++ b/integration/installers/pm_mandatory_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/paketo-buildpacks/occam"
@@ -42,7 +43,7 @@ func pmTestMandatory(t *testing.T, context spec.G, it spec.S) {
 			name, err = occam.RandomName()
 			Expect(err).NotTo(HaveOccurred())
 
-			source, err = occam.Source(filepath.Join("testdata", "conda", "pm_mandatory_app"))
+			source, err = occam.Source(filepath.Join("testdata", "pip", "pm_mandatory_app"))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -60,6 +61,7 @@ func pmTestMandatory(t *testing.T, context spec.G, it spec.S) {
 			image, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
+					settings.Buildpacks.CPython.Online,
 					settings.Buildpacks.PythonInstallers.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).
@@ -70,9 +72,7 @@ func pmTestMandatory(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred(), logs.String())
 
 			container, err = docker.Container.Run.
-				WithCommand("conda info").
-				WithPublish("8080").
-				WithPublishAll().
+				WithCommand("pip --version").
 				Execute(image.ID)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -80,7 +80,7 @@ func pmTestMandatory(t *testing.T, context spec.G, it spec.S) {
 				cLogs, err := docker.Container.Logs.Execute(container.ID)
 				Expect(err).NotTo(HaveOccurred())
 				return cLogs.String()
-			}).Should(MatchRegexp(`conda version : \d+\.\d+\.\d+`))
+			}).Should(MatchRegexp(fmt.Sprintf(`pip \d+\.\d+(\.\d+)? from /layers/%s/pip/lib/python\d+.\d+/site-packages/pip`, strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"))))
 		})
 	})
 
@@ -95,7 +95,7 @@ func pmTestMandatory(t *testing.T, context spec.G, it spec.S) {
 			name, err = occam.RandomName()
 			Expect(err).NotTo(HaveOccurred())
 
-			source, err = occam.Source(filepath.Join("testdata", "conda", "miniconda_app"))
+			source, err = occam.Source(filepath.Join("testdata", "pip", "pip_app"))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -106,6 +106,7 @@ func pmTestMandatory(t *testing.T, context spec.G, it spec.S) {
 			_, logs, err = pack.WithNoColor().Build.
 				WithPullPolicy("never").
 				WithBuildpacks(
+					settings.Buildpacks.CPython.Online,
 					settings.Buildpacks.PythonInstallers.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).

--- a/integration/installers/testdata/pip/pm_mandatory_app/plan.toml
+++ b/integration/installers/testdata/pip/pm_mandatory_app/plan.toml
@@ -3,10 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [[requires]]
-  name = "conda"
+name = "pip"
 
 [requires.metadata]
-  launch = true
+launch = true
+
+[[requires]]
+name = "cpython"
+
+[requires.metadata]
+launch = true
 
 [[requires]]
 name = "package-managers-install"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Move from conda to pip for the opt-in to use this buildpack for all package managers.

conda fails from time to time and since this test is only there temporary, let's use pip which has better consistency.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Less random CI failure

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
