### PR TITLE
chore: update miniconda installer python version

### DIFF
--- a/dependency/retrieval/main.go
+++ b/dependency/retrieval/main.go
@@ -237,7 +237,7 @@ func getAllMinicondaVersions() (versionology.VersionFetcherArray, error) {
 		return nil, err
 	}
 
-	re := regexp.MustCompile(`Miniconda3-py39_(?P<Version>\d+.\d+.\d+(-\d+)?)-Linux-(?P<Arch>x86_64|aarch64)`)
+	re := regexp.MustCompile(`Miniconda3-py310_(?P<Version>\d+.\d+.\d+(-\d+)?)-Linux-(?P<Arch>x86_64|aarch64)`)
 	matches := filtered(condaInstallersTable, re)
 
 	// Keeping only six most recent versions as otherwise it means spamming the release


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

The installer dropped py39 and thus the automation update does not pick the latest available.

This PR moves to the py310 series to stay up to date.


## Use Cases
<!-- An explanation of the use cases your change enables -->

Keep getting updates for the miniconda installer.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
